### PR TITLE
Enhancements to status summary/detail readability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1873,6 +1882,7 @@ version = "0.1.0"
 dependencies = [
  "atrium-api",
  "bsky-sdk",
+ "convert_case",
  "ipld-core",
  "lambda_http",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 atrium-api = "0.25.2"
 bsky-sdk = "0.1.18"
+convert_case = "0.8.0"
 ipld-core = "0.4.2"
 lambda_http = { version = "0.13.0", features = ["apigw_http"] }
 openssl = { version = "0.10.72", features = ["vendored"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use atrium_api::app::bsky::embed::external::ExternalData;
 use atrium_api::app::bsky::feed::post::{RecordData, RecordEmbedRefs::AppBskyEmbedExternalMain};
 use atrium_api::types::string::{Datetime, Language};
 use bsky_sdk::BskyAgent;
+use convert_case::{Case, Casing};
 use ipld_core::ipld::Ipld;
 use lambda_http::{
     run, service_fn,
@@ -74,7 +75,11 @@ impl TryFrom<StatuspageIncident> for RecordData {
             langs,
             reply: None,
             tags: None,
-            text: format!("[update] {}: {}", incident.status, update_text),
+            text: format!(
+                "[update] {}: {}",
+                incident.status.to_case(Case::Title),
+                update_text
+            ),
         })
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,7 +47,10 @@ impl TryFrom<StatuspageIncident> for RecordData {
         let latest_update = sorted_updates
             .first()
             .ok_or(Error::from("No incident update information provided"))?;
-        let update_text: String = latest_update.body.chars().take(250).collect();
+        let mut update_text: String = latest_update.body.chars().take(250).collect();
+        if latest_update.body.chars().count() > 250 {
+            update_text = format!("{}...", update_text);
+        }
 
         let embed = Some(atrium_api::types::Union::Refs(AppBskyEmbedExternalMain(
             Box::new(atrium_api::types::Object {


### PR DESCRIPTION
* Convert status summaries (e.g. `in_progress`) to title case (e.g. `In Progress`).
* Add an ellipsis (`...`) in case the status details are longer than 250 characters (rather than just cutting it off, potentially leaving a random letter or two hanging out at the end)